### PR TITLE
Dockerized cron service to automate Lightsail Outline cycling on EC2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Exclude VCS and local files from build context
+.git
+.gitignore
+node_modules
+.DS_Store
+logs
+.env
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Docker image to run Lightsail Outline cycler via cron
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies: awscli, jq, ssh client, curl/wget, cron, tzdata
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+       ca-certificates \
+       awscli \
+       jq \
+       openssh-client \
+       curl \
+       wget \
+       cron \
+       tzdata \
+  && rm -rf /var/lib/apt/lists/*
+
+# App directory
+WORKDIR /app
+
+# Copy repository contents
+COPY . /app
+
+# Ensure scripts are executable
+RUN chmod +x /app/main.sh \
+    && find /app/scripts -type f -name "*.sh" -exec chmod +x {} + \
+    && chmod +x /app/docker/entrypoint.sh /app/docker/run.sh
+
+# Create logs directory
+RUN mkdir -p /var/log \
+    && touch /var/log/cron.log
+
+# Default cron schedule (every 6 hours). Can be overridden with env CRON_SCHEDULE
+ENV CRON_SCHEDULE="0 */6 * * *"
+
+# Start cron in foreground via entrypoint (also writes cron file)
+ENTRYPOINT ["/app/docker/entrypoint.sh"]
+

--- a/README.md
+++ b/README.md
@@ -42,3 +42,101 @@ Authentication can be provided via any standard AWS mechanism:
 - Environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`
 - AWS profiles: `aws --profile <name>` or set `AWS_PROFILE`
 - IAM roles on CI/compute environments
+
+---
+
+## Run as a Dockerized cron service on your own EC2 server
+
+This repository now includes a Docker image and docker-compose setup that runs the automation every 6 hours via cron inside the container.
+
+What it does on each run:
+- Creates a new AWS Lightsail instance
+- Installs Outline via the official install script
+- Retrieves the access key (ss URL) from the Outline API
+- Uploads the connection string to S3
+- Optionally deletes older Lightsail instances to save cost
+
+### Prerequisites on your EC2 server
+
+- Docker and Docker Compose installed
+- AWS permissions available to the container via either:
+  - Instance profile (recommended): Attach an IAM role to the EC2 instance with permissions for Lightsail and S3
+  - Or environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, and `AWS_REGION`
+- A Lightsail key pair in the target region, and the corresponding private key content available as a base64-encoded, single-line string
+
+Tip: to base64-encode your Lightsail SSH private key file into a single line suitable for an env var:
+
+```bash
+base64 -w 0 < /path/to/LightsailDefaultKey-<region>.pem
+```
+
+### Configure and start
+
+1) Create a `.env` file next to `docker-compose.yml` with at least:
+
+```
+# Either rely on EC2 instance role or set these explicitly
+AWS_REGION=ap-northeast-2
+# AWS_ACCESS_KEY_ID=...
+# AWS_SECRET_ACCESS_KEY=...
+# AWS_SESSION_TOKEN=...
+
+# Required: base64 (single-line) of your Lightsail private key for the region
+LIGHTSAIL_PRIVATE_KEY_BASE64=...base64-blob...
+
+# Optional overrides
+# AVAILABILITY_ZONE=ap-northeast-2a
+# CRON_SCHEDULE=0 */6 * * *
+# S3_URI=s3://my-bucket/custom/path.txt
+# S3_BUCKET=my-bucket
+# S3_KEY=sslink.txt
+# S3_ACL=public-read
+# TZ=UTC
+```
+
+Notes:
+- Provide either `S3_URI` (full `s3://bucket/key`) or `S3_BUCKET` (and optional `S3_KEY`). If neither is provided, the default `s3://outline-link/sslink.txt` is used.
+- `CRON_SCHEDULE` uses standard cron syntax. Default is every 6 hours.
+- If your EC2 instance has an IAM role, you can omit the AWS credential env vars.
+
+2) Start the service:
+
+```bash
+docker compose up -d --build
+```
+
+3) View logs:
+
+```bash
+docker logs -f outline-cycler
+# or tail the cron log persisted to the host
+ tail -f logs/cron.log
+```
+
+### Secure configuration
+
+- Prefer using an EC2 instance profile (IAM role) to grant AWS permissions to the container. This avoids storing AWS keys on disk.
+- Store `LIGHTSAIL_PRIVATE_KEY_BASE64` in your `.env` file or a secret manager. The value must match the Lightsail region's default key pair used by `create-instances`.
+- Limit the IAM role/keys to the minimum necessary permissions: Lightsail create/get/open-ports/delete; S3 put object to your configured bucket/key.
+
+### Customization
+
+- Region and AZ: Set `AWS_REGION` and optional `AVAILABILITY_ZONE`.
+- S3 destination: Set `S3_URI` directly, or `S3_BUCKET` and optional `S3_KEY`. Default ACL is `public-read` (override with `S3_ACL`).
+- Schedule: Change `CRON_SCHEDULE` to adjust frequency.
+- Deletion behavior: By default the workflow deletes older instances after a successful run. To disable, run `main.sh --do-not-delete`. You can adapt `docker/run.sh` to pass this flag if desired.
+
+---
+
+## S3 upload configuration
+
+The upload script supports environment variables:
+- `S3_URI` (full URI) or `S3_BUCKET` and optional `S3_KEY` (defaults to `sslink.txt`).
+- `S3_ACL` for object ACL (defaults to `public-read`).
+
+---
+
+## Alternatives to cycling Lightsail IPs
+
+See `docs/ALTERNATIVES.md` for other approaches to rotate or shield IP addresses to reduce blocking while keeping costs in check.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+services:
+  outline-cycler:
+    build: .
+    container_name: outline-cycler
+    restart: unless-stopped
+    environment:
+      # Provide AWS credentials or rely on EC2 instance role
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+      - AWS_REGION=${AWS_REGION}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+
+      # Lightsail SSH private key (base64-encoded, single line)
+      - LIGHTSAIL_PRIVATE_KEY_BASE64=${LIGHTSAIL_PRIVATE_KEY_BASE64}
+
+      # Optional settings
+      - AVAILABILITY_ZONE=${AVAILABILITY_ZONE}
+      - CRON_SCHEDULE=${CRON_SCHEDULE}
+      - S3_URI=${S3_URI}
+      - S3_BUCKET=${S3_BUCKET}
+      - S3_KEY=${S3_KEY}
+      - S3_ACL=${S3_ACL}
+      - TZ=${TZ}
+
+    volumes:
+      # Persist cron logs to the host (optional)
+      - ./logs:/var/log
+

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create cron file with environment variables and schedule
+CRON_FILE="/etc/cron.d/outline-cycler"
+LOG_FILE="/var/log/cron.log"
+
+# Ensure log file exists
+mkdir -p "$(dirname "$LOG_FILE")"
+touch "$LOG_FILE"
+
+# Default schedule if not provided
+: "${CRON_SCHEDULE:=0 */6 * * *}"
+
+# Helper to append a VAR=value line if set
+append_env() {
+  local var="$1"
+  if [ -n "${!var-}" ]; then
+    # Do not quote; cron treats quotes as literal characters
+    echo "$var=${!var}" >> "$CRON_FILE"
+  fi
+}
+
+# Build cron file
+{
+  echo "SHELL=/bin/bash"
+  echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+} > "$CRON_FILE"
+
+# Pass through selected environment variables for the job
+for v in \
+  AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
+  AWS_REGION AWS_DEFAULT_REGION AWS_PROFILE \
+  LIGHTSAIL_PRIVATE_KEY_BASE64 AVAILABILITY_ZONE \
+  S3_URI S3_BUCKET S3_KEY S3_ACL TZ \
+  DELETE_INSTANCES INSTANCE_NAME
+do
+  append_env "$v"
+done
+
+# Cron job line: run every N hours and log output
+{
+  echo ""
+  echo "$CRON_SCHEDULE root /app/docker/run.sh >> $LOG_FILE 2>&1"
+} >> "$CRON_FILE"
+
+# Correct permissions per cron.d requirements
+chmod 0644 "$CRON_FILE"
+
+# Print the cron file for visibility
+echo "[entrypoint] Installed cron file:" && cat "$CRON_FILE"
+
+# Start cron in foreground
+exec cron -f -L 2
+

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /app
+
+echo "[$(date -Iseconds)] Starting Outline Lightsail cycler run"
+
+# Run the main workflow
+bash ./main.sh
+
+EXIT_CODE=$?
+
+echo "[$(date -Iseconds)] Completed run with exit code: $EXIT_CODE"
+exit $EXIT_CODE
+

--- a/docs/ALTERNATIVES.md
+++ b/docs/ALTERNATIVES.md
@@ -1,0 +1,45 @@
+# Alternatives to cycling Lightsail instances/IPs
+
+If the goal is to maintain a healthy Outline connection while avoiding IP blocks, here are some alternatives and trade-offs:
+
+- Elastic IP rotation with EC2
+  - Maintain a small EC2 instance and allocate multiple Elastic IPs (limited per account/region; you can request increases).
+  - Detach/attach EIPs to shift IPs rapidly without recreating hosts.
+  - Pros: Faster switching, stable underlying instance, can prewarm app.
+  - Cons: EIPs incur cost when unattached; may still be blocked; service interruptions during swaps.
+
+- NAT Gateway or NAT Instance
+  - Run Outline behind a NAT and rotate the upstream egress IP by swapping NAT gateways/instances or using multiple NAT instances with different EIPs.
+  - Pros: Centralized control over egress IP.
+  - Cons: NAT Gateways have hourly + data processing costs; NAT instances require maintenance.
+
+- AWS Global Accelerator or CloudFront (with TCP/UDP support constraints)
+  - Front Outline with a global anycast IP and backends placed across regions.
+  - Pros: Stable global IPs and performance.
+  - Cons: Not applicable to all protocols/ports and may violate provider ToS; additional cost.
+
+- AWS Network Load Balancer per-session IPs
+  - NLB can expose static IPs per AZ. Rotating target groups or NLBs can change exposure.
+  - Pros: Managed and scalable.
+  - Cons: More complex and may not suit Outline's port needs.
+
+- Multiple regions/pools
+  - Maintain a pool of low-cost instances across regions; rotate DNS to new IPs when blocks happen.
+  - Pros: Distributes reputation risk across regions/providers.
+  - Cons: Requires orchestration, health checks, and DNS TTL management.
+
+- Provider diversity
+  - Mix AWS with other clouds (GCP/Linode/DigitalOcean) to reduce correlation of abuse reports to a single provider.
+
+- Residential proxy providers / ISP IPs
+  - Use third-party networks offering residential egress IPs (check legal/policy constraints).
+  - Pros: Less likely to be blocked quickly.
+  - Cons: Cost and compliance concerns.
+
+- Firewall/rate-limiting and port management
+  - Only expose essential ports, rotate Shadowsocks ports, and rate-limit to reduce detection.
+
+Notes:
+- Always review AWS acceptable use policies and local laws.
+- Evaluate cost vs. complexity; Lightsail cycling is cheap and simple but causes downtime during each rotation.
+

--- a/scripts/upload-sslink-to-s3.sh
+++ b/scripts/upload-sslink-to-s3.sh
@@ -8,10 +8,29 @@ trap "rm -f $SS_LINK_FILEPATH" EXIT
 # Retrieve ssLink from input
 ssLink=$1
 
-echo "Uploading ss key $ssLink to S3"
+if [ -z "$ssLink" ]; then
+  echo "No Shadowsocks link provided to upload-sslink-to-s3.sh"
+  exit 1
+fi
+
+# Determine destination S3 URI
+# Priority: S3_URI env > S3_BUCKET (+ optional S3_KEY) > default bucket/path
+DEST_URI="${S3_URI:-}"
+if [ -z "$DEST_URI" ]; then
+  if [ -n "${S3_BUCKET:-}" ]; then
+    DEST_URI="s3://${S3_BUCKET}/${S3_KEY:-sslink.txt}"
+  else
+    DEST_URI="s3://outline-link/sslink.txt"
+  fi
+fi
+
+ACL_OPT="${S3_ACL:-public-read}"
+
+echo "Uploading ss key to $DEST_URI (acl=$ACL_OPT)"
 
 # Save the access key in `sslink.txt`
-echo $ssLink > $SS_LINK_FILEPATH
+echo "$ssLink" > "$SS_LINK_FILEPATH"
 
 # Copy the updated `SS_LINK_FILEPATH` to AWS S3 bucket
-aws s3 cp $SS_LINK_FILEPATH s3://outline-link/sslink.txt --acl public-read
+aws s3 cp "$SS_LINK_FILEPATH" "$DEST_URI" --acl "$ACL_OPT"
+


### PR DESCRIPTION
Summary
- Add Dockerfile that packages awscli, jq, ssh client, cron, and scripts
- Add docker-compose.yml so you can `docker compose up -d` on your EC2 host
- Implement cron inside the container (default every 6 hours) via an entrypoint that writes /etc/cron.d job and runs cron in foreground
- Add docker/run.sh to invoke main.sh and log timestamps
- Parameterize S3 destination for the Outline access URL with S3_URI/S3_BUCKET/S3_KEY/S3_ACL (fallback remains s3://outline-link/sslink.txt)
- Add .dockerignore to keep builds lean
- Update README with full setup instructions, security guidance, and operations notes
- Add docs/ALTERNATIVES.md with other approaches to rotating/avoiding IP blocks

How it works
- The container runs cron which executes /app/docker/run.sh on the configured schedule (default: 0 */6 * * *)
- The run script calls main.sh which:
  - Creates a Lightsail instance
  - Installs Outline via the official script
  - Fetches the access key URL
  - Uploads it to S3 (now configurable)
  - Deletes older instances by default
- The entrypoint writes a cron file that includes important environment variables (AWS credentials, LIGHTSAIL_PRIVATE_KEY_BASE64, region/AZ, and S3 settings), then starts cron in foreground

Usage
1) On your EC2 server, create a .env alongside docker-compose.yml:

AWS_REGION=ap-northeast-2
# AWS_ACCESS_KEY_ID=...
# AWS_SECRET_ACCESS_KEY=...
# AWS_SESSION_TOKEN=...
LIGHTSAIL_PRIVATE_KEY_BASE64=...base64-blob...
# Optional overrides
# AVAILABILITY_ZONE=ap-northeast-2a
# CRON_SCHEDULE=0 */6 * * *
# S3_URI=s3://my-bucket/sslink.txt
# S3_BUCKET=my-bucket
# S3_KEY=sslink.txt
# S3_ACL=public-read
# TZ=UTC

2) Start: `docker compose up -d --build`
3) Check logs: `docker logs -f outline-cycler` or `tail -f logs/cron.log`

Security and permissions
- Prefer attaching an IAM role (instance profile) to the EC2 instance with minimum required permissions for Lightsail and S3; otherwise, set AWS_* env vars
- Provide the Lightsail region's default SSH private key as a base64 one-liner in LIGHTSAIL_PRIVATE_KEY_BASE64

Notes
- Backwards-compatible S3 behavior: if no S3_* envs are set, uploads go to s3://outline-link/sslink.txt as before
- You can customize the cron frequency with CRON_SCHEDULE and availability zone via AVAILABILITY_ZONE
- If you want to keep previous instances (no cleanup), you can adapt docker/run.sh to pass `--do-not-delete` to main.sh

Alternatives
- See docs/ALTERNATIVES.md for approaches such as EIP rotation, NAT instances/gateways, NLB/Global Accelerator considerations, and region/provider diversification

Testing
- Basic shell syntax validation done (`bash -n` on scripts)
- This change does not alter the existing GitHub Actions workflow; it adds an EC2-hosted runtime option as requested

Closes #1